### PR TITLE
Update Test Configs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  projects: [
+    '<rootDir>/packages/datastore/jest.config.js',
+    '<rootDir>/packages/structures/jest.config.js',
+  ],
+  transform: {
+    '^.+\\.jsx?$': require.resolve('babel-jest'),
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "yarn workspaces run build",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
-    "test": "yarn workspaces run test"
+    "test": "jest",
+    "coverage": "jest --coverage"
   },
   "workspaces": [
     "packages/*"

--- a/packages/datastore/jest.config.js
+++ b/packages/datastore/jest.config.js
@@ -1,8 +1,9 @@
-const path = require('path');
+const pkg = require('./package');
 
 module.exports = {
+  displayName: pkg.name,
   transform: {
-    '^.+\\.jsx?$': path.resolve(__dirname, '../../config/babelJestTransformer.js'),
+    '^.+\\.jsx?$': '<rootDir>/../../config/babelJestTransformer.js',
   },
   verbose: false,
   collectCoverageFrom: ['src/**/*.js', '!src/index.js', '!src/__tests__/__utils__/'],

--- a/packages/structures/jest.config.js
+++ b/packages/structures/jest.config.js
@@ -1,8 +1,9 @@
-const path = require('path');
+const pkg = require('./package');
 
 module.exports = {
+  displayName: pkg.name,
   transform: {
-    '^.+\\.jsx?$': path.resolve(__dirname, '../../config/babelJestTransformer.js'),
+    '^.+\\.jsx?$': '<rootDir>/../../config/babelJestTransformer.js',
   },
   verbose: false,
   collectCoverageFrom: ['src/**/*.js', '!src/index.js', '!src/__tests__/__utils__/'],


### PR DESCRIPTION
## Changes
- Add root jest config
  - allows jest to run on the root level for all packages that have testing setup (this is now used by the `test` script in the root level package.json)
- Update jest configs in `Datastore` and `Structures` package
  - Add name to config so it shows up when run on the root level
  - Use `<rootDir>` instead of `__dirname` to specify the starting directory. This doesn't change anything but adheres more to what `jest` expects.
- Update root `test` command to use `jest`
- Add `coverage` command to generate coverage report for all projects that have tests.

## Manual Checks
- [x] Ensure `install` works
- [x] Run `test` and make sure both `datastore` and `structures` unit tests are run
- [x] Run `coverage` and make sure coverage report includes both the `datastore` and `structures` packages
- [x] Make sure individual test suites still work
  - [x] when triggered from the root directory
    - ensure `yarn workspace @monitor/structures run test` works properly
    - ensure `yarn workspace @monitor/datastore run test` works properly
  - [x] when triggered from the package directory
    - ensure `yarn run test` works when run in `<rootDir>/packages/structures`
    - ensure `yarn run test` works when run in `<rootDir>/packages/datastore`