### PR TITLE
Add Product and Webhook Group Management to GraphQL Schema

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
     "express-graphql": "^0.8.0",
     "graphql": "^14.2.1",
     "react-grid-system": "^4.4.3",
-    "shortid": "^2.2.14"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "concurrently": "^4.1.0",

--- a/packages/server/src/api/resolver.js
+++ b/packages/server/src/api/resolver.js
@@ -1,7 +1,16 @@
+import uuidv4 from 'uuid/v4';
+
 import { MemoryStore, RedisStore, Datasources } from '@monitor/datastore';
 import { initialStates, utils } from '@monitor/structures';
 
-const { monitorInfoState, productState, proxyState, settingsState, siteState } = initialStates;
+const {
+  monitorInfoState,
+  productState,
+  proxyState,
+  settingsState,
+  siteState,
+  webhookGroupState,
+} = initialStates;
 const { buildProxyInfo } = utils;
 
 class Resolver {
@@ -129,32 +138,124 @@ class Resolver {
     return settings;
   }
 
+  async browseWebhookGroups() {
+    return this.store.webhooks.browse();
+  }
+
+  async readWebhookGroup(id) {
+    return this.store.webhooks.read(id);
+  }
+
+  async addWebhookGroup(data) {
+    // Supplement missing data with initial state until
+    // partial webhook group objects are supported
+    const groupData = {
+      ...webhookGroupState,
+      ...data,
+    };
+    return this.store.webhooks.add(groupData);
+  }
+
+  async editWebhookGroup(id, data) {
+    // Supplement missing data with initial state until
+    // partial webhook group objects are supported
+    const groupData = {
+      ...webhookGroupState,
+      ...data,
+    };
+    return this.store.webhooks.edit(id, groupData);
+  }
+
   async browseWebhooks() {
-    return this.store.sites.browse();
+    const webhookGroups = await this.browseWebhookGroups();
+    const webhookMap = {};
+    webhookGroups.forEach(group => {
+      group.webhooks.forEach(w => {
+        // Add webhook if it hasn't already been added.
+        if (!webhookMap[w.id]) {
+          webhookMap[w.id] = w;
+        }
+      });
+    });
+    return Object.values(webhookMap);
   }
 
-  async readWebhook(id) {
-    return this.store.sites.read(id);
+  async readWebhook(id, groupId, groupName) {
+    if (groupId) {
+      // Attempt to get the single group instead of all groups
+      // If webhook is not found, fallback to looking through all groups
+      const group = await this.readWebhookGroup(id);
+      const webhook = group.webhooks.find(w => w.id === id);
+      if (webhook) {
+        return webhook;
+      }
+    }
+    let groups = await this.browseWebhookGroups();
+    if (groupName) {
+      // Attempt to filter out groups based on group name
+      // Fallback to full list if there are no groups with the matching name
+      const filtered = groups.filter(g => g.name === groupName);
+      if (filtered.length) {
+        groups = filtered;
+      }
+    }
+    const webhookMap = {};
+    groups.forEach(group => {
+      group.webhooks.forEach(w => {
+        // Add webhook if it hasn't already been added.
+        if (!webhookMap[w.id]) {
+          webhookMap[w.id] = w;
+        }
+      });
+    });
+    return webhookMap[id];
   }
 
-  async addWebhook(data) {
+  async addWebhook(data, groupId) {
     // Supplement missing data with initial state until
     // partial site objects are supported
     const siteData = {
       ...siteState,
       ...data,
     };
-    return this.store.sites.add(siteData);
+    try {
+      const group = await this.readWebhookGroup(groupId);
+      const existingIdx = group.webhooks.findIndex(w => w.url === siteData.url);
+      if (existingIdx === -1) {
+        group.webhooks.push({
+          ...siteData,
+          id: uuidv4(),
+        });
+        return this.editWebhookGroup(groupId, group);
+      }
+      const oldWebhook = group.webhooks[existingIdx];
+      group.webhooks[existingIdx] = {
+        ...oldWebhook,
+        ...data,
+      };
+      return this.editWebhookGroup(groupId, group);
+    } catch (_) {
+      throw new Error('Invalid group id!');
+    }
   }
 
-  async editWebhook(id, data) {
-    // Supplement missing data with initial state until
-    // partial site objects are supported
-    const siteData = {
-      ...siteState,
-      ...data,
-    };
-    return this.store.sites.edit(id, siteData);
+  async editWebhook(id, data, groupId) {
+    try {
+      const group = await this.readWebhookGroup(groupId);
+      const existingIdx = group.webhooks.findIndex(w => w.id === id);
+      if (existingIdx === -1) {
+        // no existing webhook, add it instead
+        return this.addWebhook(data, groupId);
+      }
+      const oldWebhook = group.webhooks[existingIdx];
+      group.webhooks[existingIdx] = {
+        ...oldWebhook,
+        ...data,
+      };
+      return this.editWebhookGroup(groupId, group);
+    } catch (_) {
+      throw new Error('Invalid group id!');
+    }
   }
 
   async browseMonitors() {

--- a/packages/server/src/api/v1/schema.js
+++ b/packages/server/src/api/v1/schema.js
@@ -21,6 +21,8 @@ const {
     SettingsInputType,
     SiteType,
     SiteInputType,
+    WebhookGroupType,
+    WebhookGroupInputType,
   },
 } = structures;
 
@@ -65,9 +67,25 @@ const query = new GraphQLObjectType({
       description: 'Retrieve settings',
       resolve: root => root.getSettings(),
     },
+    webhookGroups: {
+      type: GraphQLList(GraphQLNonNull(WebhookGroupType)),
+      description: 'Retrieve stored webhook groups',
+      resolve: root => root.browseWebhookGroups(),
+    },
+    webhookGroup: {
+      type: WebhookGroupType,
+      description: 'Retrieve webhook group for specific id',
+      args: {
+        id: {
+          type: GraphQLNonNull(GraphQLString),
+          description: 'id of webhook group to retrieve',
+        },
+      },
+      resolve: (root, { id }) => root.readWebhookGroup(id),
+    },
     webhooks: {
       type: GraphQLList(GraphQLNonNull(SiteType)),
-      description: 'Retrieve stored webhooks',
+      description: 'Retrieve stored webhooks from all groups',
       resolve: root => root.browseWebhooks(),
     },
     webhook: {
@@ -78,8 +96,16 @@ const query = new GraphQLObjectType({
           type: GraphQLNonNull(GraphQLString),
           description: 'id of webhook to retrieve',
         },
+        groupId: {
+          type: GraphQLString,
+          description: 'id of group to narrow down search (Optional)',
+        },
+        groupName: {
+          type: GraphQLString,
+          description: 'name of group to narrow down search (Optional)',
+        },
       },
-      resolve: (root, { id }) => root.readWebhook(id),
+      resolve: (root, { id, groupId, groupName }) => root.readWebhook(id, groupId, groupName),
     },
     monitors: {
       type: GraphQLList(GraphQLNonNull(MonitorInfoType)),
@@ -193,6 +219,32 @@ const mutation = new GraphQLObjectType({
       },
       resolve: (root, { data }) => root.updateSettings(data),
     },
+    addWebhookGroup: {
+      type: WebhookGroupType,
+      description: 'Add a new webhook group',
+      args: {
+        data: {
+          type: GraphQLNonNull(WebhookGroupInputType),
+          description: 'Webhook group info to add',
+        },
+      },
+      resolve: (root, { data }) => root.addWebhookGroup(data),
+    },
+    editWebhookGroup: {
+      type: WebhookGroupType,
+      description: 'Edit an existing webhook group',
+      args: {
+        id: {
+          type: GraphQLNonNull(GraphQLString),
+          description: 'id of webhook group to update',
+        },
+        data: {
+          type: GraphQLNonNull(WebhookGroupInputType),
+          description: 'Webhook group info to update',
+        },
+      },
+      resolve: (root, { id, data }) => root.editWebhookGroup(id, data),
+    },
     addWebhook: {
       type: SiteType,
       description: 'Add a new webhook',
@@ -201,8 +253,12 @@ const mutation = new GraphQLObjectType({
           type: GraphQLNonNull(SiteInputType),
           description: 'webhook info to add',
         },
+        groupId: {
+          type: GraphQLNonNull(GraphQLString),
+          description: 'webhook group to associate with the webhook',
+        },
       },
-      resolve: (root, { data }) => root.addWebhook(data),
+      resolve: (root, { data, groupId }) => root.addWebhook(data, groupId),
     },
     editWebhook: {
       type: SiteType,
@@ -216,8 +272,12 @@ const mutation = new GraphQLObjectType({
           type: GraphQLNonNull(SiteInputType),
           description: 'updated webhook info',
         },
+        groupId: {
+          type: GraphQLNonNull(GraphQLString),
+          description: 'webhook group associated with webhook',
+        },
       },
-      resolve: (root, { data }) => root.editWebhook(data),
+      resolve: (root, { id, data, groupId }) => root.editWebhook(id, data, groupId),
     },
     addMonitor: {
       type: MonitorInfoType,


### PR DESCRIPTION
## Changes
- Add product management to graphql schema
- Add webhook group management to graphql schema
- Update individual webhook management in graphql schema
  - adding/editing requires a `groupId` for the specific webhook group
  - reading allows an optional `groupId` and `groupName` to help narrow down search results

## Checks
- [x] no lints (`yarn workspace @monitor/server run lint)
- [x] ~~Tests pass~~ Unit tests will be added later
